### PR TITLE
Avoid uninitialized constant WEBrick::HTTPStatus::Status::AccessLog

### DIFF
--- a/lib/bitchannel/cgi.rb
+++ b/lib/bitchannel/cgi.rb
@@ -10,6 +10,7 @@
 
 require 'bitchannel/handler'
 require 'webrick/cgi'
+require 'webrick/accesslog'
 
 module WEBrick
   class CGI   # reopen


### PR DESCRIPTION
Ubuntuで運用しているとたまに下記のようなエラーが出ます。どう回避するのが良いのかよくわからないのですが。

```
BitChannel Error
uninitialized constant WEBrick::HTTPStatus::Status::AccessLog (NameError)
/usr/lib/ruby/2.0.0/webrick/httpstatus.rb:24:in `initialize'
/home/www/wiki/bitchannel/lib/bitchannel/handler.rb:60:in `exception'
/home/www/wiki/bitchannel/lib/bitchannel/handler.rb:60:in `raise'
/home/www/wiki/bitchannel/lib/bitchannel/handler.rb:60:in `check_IfModifiedSince'
/home/www/wiki/bitchannel/lib/bitchannel/handler.rb:39:in `handle'
/home/www/wiki/bitchannel/lib/bitchannel/cgi.rb:42:in `block in do_GET'
/home/www/wiki/bitchannel/lib/bitchannel/wikispace.rb:42:in `session'
/home/www/wiki/bitchannel/lib/bitchannel/cgi.rb:41:in `do_GET'
/usr/lib/ruby/2.0.0/webrick/cgi.rb:159:in `service'
/usr/lib/ruby/2.0.0/webrick/cgi.rb:116:in `start'
/home/www/wiki/bitchannel/lib/bitchannel/cgi.rb:27:in `block in run'
/home/www/wiki/bitchannel/lib/bitchannel/cgi.rb:22:in `each_request'
/home/www/wiki/bitchannel/lib/bitchannel/cgi.rb:26:in `run'
/home/www/wiki/bitchannel/lib/bitchannel/cgi.rb:18:in `main'
/home/www/wiki/bitchannel/lib/bitchannel/cgi.rb:36:in `main'
/home/www/html/w/index.cgi:14:in `<main>'
```
