### PR TITLE
Make it possible to run BitChannel on Ubuntu 22.04 with ruby 3.0

### DIFF
--- a/README.ja
+++ b/README.ja
@@ -12,6 +12,8 @@ BitChannel README
   * Ruby 1.8.1 以上
   * CVS 1.10 以上
   * uconv.so (なくても構いません)
+  * Webrick gem
+  * Addressable gem
 
   作者は以下の環境で開発しています。
 

--- a/lib/bitchannel/page.rb
+++ b/lib/bitchannel/page.rb
@@ -11,6 +11,8 @@
 require 'bitchannel/erbutils'
 require 'bitchannel/textutils'
 
+require 'addressable/uri'
+
 module BitChannel
 
   # place holder for farm service methods.
@@ -53,7 +55,7 @@ module BitChannel
     end
 
     def escape_url(str)
-      escape_html(URI.escape(str))
+      escape_html(Addressable::URI.escape(str))
     end
   end
 


### PR DESCRIPTION
ご無沙汰しています。BitChannelを利用させていただいている家のサーバのOSをやっとのことでUbuntu 20.04から22.04に更新しました。Rubyが2.7から3.0になり、ruby-webrickとruby-addressableをapt installしてURI.escape()をAddressable::URI.escape()に変更することで動かすことができました。ご参考まで。